### PR TITLE
[PLUGIN-1472] Adding support to calculate categorical.nulls correctly

### DIFF
--- a/src/main/java/io/cdap/plugin/Profile.java
+++ b/src/main/java/io/cdap/plugin/Profile.java
@@ -56,5 +56,4 @@ public abstract class Profile {
   }
 
   public abstract void results(StructuredRecord.Builder builder);
-
 }

--- a/src/main/java/io/cdap/plugin/Profile.java
+++ b/src/main/java/io/cdap/plugin/Profile.java
@@ -56,4 +56,12 @@ public abstract class Profile {
   }
 
   public abstract void results(StructuredRecord.Builder builder);
+
+  public long getNulls() {
+    return 0;
+  }
+
+  public long getCount() {
+    return 0;
+  }
 }

--- a/src/main/java/io/cdap/plugin/Profile.java
+++ b/src/main/java/io/cdap/plugin/Profile.java
@@ -57,11 +57,4 @@ public abstract class Profile {
 
   public abstract void results(StructuredRecord.Builder builder);
 
-  public long getNulls() {
-    return 0;
-  }
-
-  public long getCount() {
-    return 0;
-  }
 }

--- a/src/main/java/io/cdap/plugin/profiles/Categorical.java
+++ b/src/main/java/io/cdap/plugin/profiles/Categorical.java
@@ -132,17 +132,4 @@ public final class Categorical extends Profile {
     builder.set("quadratic_mean", V(statistics.getQuadraticMean()));
   }
 
-  /**
-    * Method for retrieving private data variable nulls
-    */
-  public long getNulls() {
-    return nulls;
-  }
-
-  /**
-   * Method for retrieving private data variable nulls
-   */
-  public long getCount() {
-    return count;
-  }
 }

--- a/src/main/java/io/cdap/plugin/profiles/Categorical.java
+++ b/src/main/java/io/cdap/plugin/profiles/Categorical.java
@@ -97,16 +97,14 @@ public final class Categorical extends Profile {
   @Override
   public void update(Object value) {
     count = count + 1;
-    if (value instanceof String) {
-      if (value == null) {
-        nulls = nulls + 1;
+    if (value == null) {
+      nulls = nulls + 1;
+    } else if (value instanceof String) {
+      String val = (String) value;
+      if (val.isEmpty()) {
+        empty = empty + 1;
       } else {
-        String val = (String) value;
-        if (val.isEmpty()) {
-          empty = empty + 1;
-        } else {
-          statistics.addValue(val.length());
-        }
+        statistics.addValue(val.length());
       }
     }
   }

--- a/src/main/java/io/cdap/plugin/profiles/Categorical.java
+++ b/src/main/java/io/cdap/plugin/profiles/Categorical.java
@@ -131,4 +131,18 @@ public final class Categorical extends Profile {
     builder.set("population_variance", V(statistics.getPopulationVariance()));
     builder.set("quadratic_mean", V(statistics.getQuadraticMean()));
   }
+
+  /**
+    * Method for retrieving private data variable nulls
+    */
+  public long getNulls() {
+    return nulls;
+  }
+
+  /**
+   * Method for retrieving private data variable nulls
+   */
+  public long getCount() {
+    return count;
+  }
 }

--- a/src/main/java/io/cdap/plugin/profiles/Categorical.java
+++ b/src/main/java/io/cdap/plugin/profiles/Categorical.java
@@ -131,5 +131,4 @@ public final class Categorical extends Profile {
     builder.set("population_variance", V(statistics.getPopulationVariance()));
     builder.set("quadratic_mean", V(statistics.getQuadraticMean()));
   }
-
 }

--- a/src/test/java/io/cdap/plugin/DefaultProfilerTest.java
+++ b/src/test/java/io/cdap/plugin/DefaultProfilerTest.java
@@ -60,10 +60,6 @@ public class DefaultProfilerTest {
     StructuredRecord result = profiler.result("s");
     Assert.assertNotNull(result);
     Assert.assertNotNull(outputSchema);
-    profiler.update("s", null);
-    result = profiler.result("s");
-    Assert.assertNotNull(result);
-    Assert.assertNotNull(outputSchema);
   }
 
   @Test

--- a/src/test/java/io/cdap/plugin/DefaultProfilerTest.java
+++ b/src/test/java/io/cdap/plugin/DefaultProfilerTest.java
@@ -60,6 +60,10 @@ public class DefaultProfilerTest {
     StructuredRecord result = profiler.result("s");
     Assert.assertNotNull(result);
     Assert.assertNotNull(outputSchema);
+    profiler.update("s", null);
+    result = profiler.result("s");
+    Assert.assertNotNull(result);
+    Assert.assertNotNull(outputSchema);
   }
 
   @Test

--- a/src/test/java/io/cdap/plugin/DefaultProfilerTest.java
+++ b/src/test/java/io/cdap/plugin/DefaultProfilerTest.java
@@ -67,6 +67,20 @@ public class DefaultProfilerTest {
   }
 
   @Test
+  public void testNullCount() {
+    List<Profile> profiles = new ArrayList<>();
+    profiles.add(new Categorical());
+    Profiler profiler = new DefaultProfiler(profiles, schema);
+    StructuredRecord result = profiler.result("s");
+    profiler.update("s", null);
+    profiler.update("s", null);
+    profiler.update("s", "1");
+    profiler.update("s", null);
+    Assert.assertEquals(3, profiles.get(0).getNulls());
+    Assert.assertEquals(1, profiles.get(0).getCount() - profiles.get(0).getNulls());
+  }
+
+  @Test
   public void testHyperLogLog() throws Exception {
     HyperLogLogPlus hll = new HyperLogLogPlus(32, 32);
     hll.offer("a");

--- a/src/test/java/io/cdap/plugin/DefaultProfilerTest.java
+++ b/src/test/java/io/cdap/plugin/DefaultProfilerTest.java
@@ -71,13 +71,17 @@ public class DefaultProfilerTest {
     List<Profile> profiles = new ArrayList<>();
     profiles.add(new Categorical());
     Profiler profiler = new DefaultProfiler(profiles, schema);
-    StructuredRecord result = profiler.result("s");
     profiler.update("s", null);
     profiler.update("s", null);
     profiler.update("s", "1");
     profiler.update("s", null);
-    Assert.assertEquals(3, profiles.get(0).getNulls());
-    Assert.assertEquals(1, profiles.get(0).getCount() - profiles.get(0).getNulls());
+    StructuredRecord record = profiler.result("s");
+    StructuredRecord subrecord = record.get("categorical");
+    Assert.assertNotNull(subrecord);
+    long nulls = subrecord.get("nulls");
+    long non_nulls = subrecord.get("non_nulls");
+    Assert.assertEquals(3, nulls);
+    Assert.assertEquals(1, non_nulls);
   }
 
   @Test


### PR DESCRIPTION
Bug: https://cdap.atlassian.net/browse/PLUGIN-1472

Data Profiler plugin was not calculating count of nulls and non-nulls correctly. 

