### PR TITLE
Removing SNAPSHOT from plugin version in pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>io.cdap.plugin</groupId>
   <artifactId>data-profiler</artifactId>
-  <version>1.1.1-SNAPSHOT</version>
+  <version>1.1.1</version>
   <packaging>jar</packaging>
   <name>Data Profiler for generating statistics on the fields being processed of a feed.</name>
 


### PR DESCRIPTION
Changed data-profiler version from 1.1.1-SNAPSHOT to 1.1.1 in pom.xml